### PR TITLE
refactor(retry): consolidate slog adapter, fix timer leak, and improve retry loop

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,26 +18,5 @@ func (nopLogger) Info(string, ...any)  {}
 func (nopLogger) Warn(string, ...any)  {}
 func (nopLogger) Error(string, ...any) {}
 
-// slogAdapter wraps slog.Logger to implement our Logger interface
-type slogAdapter struct {
-	logger *slog.Logger
-}
-
-func (l *slogAdapter) Debug(msg string, args ...any) {
-	l.logger.Debug(msg, args...)
-}
-
-func (l *slogAdapter) Info(msg string, args ...any) {
-	l.logger.Info(msg, args...)
-}
-
-func (l *slogAdapter) Warn(msg string, args ...any) {
-	l.logger.Warn(msg, args...)
-}
-
-func (l *slogAdapter) Error(msg string, args ...any) {
-	l.logger.Error(msg, args...)
-}
-
-// defaultLogger uses slog.Default() which outputs to stderr with INFO level
-var defaultLogger Logger = &slogAdapter{logger: slog.Default()}
+// defaultLogger uses slog.Default() which outputs to stderr at INFO level
+var defaultLogger Logger = &SlogAdapter{logger: slog.Default()}

--- a/logger_test.go
+++ b/logger_test.go
@@ -164,9 +164,9 @@ func TestClient_DefaultLogger(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	// Verify the default logger is slogAdapter (not nopLogger)
-	if _, ok := client.logger.(*slogAdapter); !ok {
-		t.Errorf("Expected default logger to be *slogAdapter, got %T", client.logger)
+	// Verify the default logger is SlogAdapter (not nopLogger)
+	if _, ok := client.logger.(*SlogAdapter); !ok {
+		t.Errorf("Expected default logger to be *SlogAdapter, got %T", client.logger)
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)

--- a/metric.go
+++ b/metric.go
@@ -35,30 +35,42 @@ func (nopMetricsCollector) RecordRequestComplete(string, int, time.Duration, int
 // defaultMetrics is the package-level singleton (internal use, not exported)
 var defaultMetrics = nopMetricsCollector{}
 
+// Retry reason constants for metrics and logging
+const (
+	RetryReasonTimeout     = "timeout"
+	RetryReasonCanceled    = "canceled"
+	RetryReasonNetworkErr  = "network_error"
+	RetryReasonRateLimited = "rate_limited"
+	RetryReason5xx         = "5xx"
+	RetryReason4xx         = "4xx"
+	RetryReasonUnknown     = "unknown"
+	RetryReasonOther       = "other"
+)
+
 // determineRetryReason categorizes the retry reason (for metrics and logging)
 func determineRetryReason(err error, resp *http.Response) string {
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return "timeout"
+			return RetryReasonTimeout
 		}
 		if errors.Is(err, context.Canceled) {
-			return "canceled"
+			return RetryReasonCanceled
 		}
-		return "network_error"
+		return RetryReasonNetworkErr
 	}
 
 	if resp == nil {
-		return "unknown"
+		return RetryReasonUnknown
 	}
 
 	switch {
 	case resp.StatusCode == 429:
-		return "rate_limited"
+		return RetryReasonRateLimited
 	case resp.StatusCode >= 500:
-		return "5xx"
+		return RetryReason5xx
 	case resp.StatusCode >= 400:
-		return "4xx"
+		return RetryReason4xx
 	default:
-		return "other"
+		return RetryReasonOther
 	}
 }

--- a/retry.go
+++ b/retry.go
@@ -470,15 +470,14 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 		)
 	}
 
-	var nextDelayBase time.Duration // Base delay for next retry (before modifiers)
-	var shouldWait bool             // Whether to wait before this attempt
+	var nextDelayBase time.Duration   // Base delay for next retry (before modifiers)
+	var nextActualDelay time.Duration // Actual delay (after Retry-After, jitter, cap)
+	var nextRetryAfter time.Duration  // Retry-After duration from response header
+	var shouldWait bool               // Whether to wait before this attempt
 
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
 		// === PHASE 1: Wait for delay (if retrying) ===
 		if shouldWait && attempt > 0 {
-			// Apply Retry-After, jitter, cap
-			actualDelay, retryAfterDelay := c.applyDelayModifiers(nextDelayBase, resp)
-
 			// Call onRetry callback
 			if c.onRetryFunc != nil {
 				statusCode := 0
@@ -487,10 +486,10 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 				}
 				c.onRetryFunc(RetryInfo{
 					Attempt:      attempt,
-					Delay:        actualDelay,
+					Delay:        nextActualDelay,
 					Err:          lastErr,
 					StatusCode:   statusCode,
-					RetryAfter:   retryAfterDelay,
+					RetryAfter:   nextRetryAfter,
 					TotalElapsed: time.Since(startTime),
 				})
 			}
@@ -500,13 +499,15 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 				c.logger.Info("retrying request",
 					"method", req.Method,
 					"attempt", attempt+1,
-					"delay_ms", actualDelay.Milliseconds(),
+					"delay_ms", nextActualDelay.Milliseconds(),
 				)
 			}
 
 			// Wait for delay
+			timer := time.NewTimer(nextActualDelay)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				// Context cancelled during wait
 				statusCode := 0
 				if resp != nil {
@@ -518,7 +519,7 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 					LastStatus: statusCode,
 					Elapsed:    time.Since(startTime),
 				}
-			case <-time.After(actualDelay):
+			case <-timer.C:
 				// Continue to attempt
 			}
 		}
@@ -575,11 +576,14 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 				)
 			}
 
-			// Preview actual delay (for logging)
-			previewDelay, _ := c.applyDelayModifiers(nextDelayBase, resp)
+			// Apply Retry-After, jitter, and max cap
+			nextActualDelay, nextRetryAfter = c.applyDelayModifiers(nextDelayBase, resp)
 
 			// Record retry decision
-			retryReason := determineRetryReason(lastErr, resp)
+			var retryReason string
+			if c.metricsEnabled || c.loggerEnabled || c.tracerEnabled {
+				retryReason = determineRetryReason(lastErr, resp)
+			}
 			if c.metricsEnabled {
 				c.metrics.RecordRetry(req.Method, retryReason, attempt+1)
 			}
@@ -591,7 +595,7 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 					"url", req.URL.String(),
 					"attempt", attempt + 1,
 					"reason", retryReason,
-					"next_delay_ms", previewDelay.Milliseconds(),
+					"next_delay_ms", nextActualDelay.Milliseconds(),
 					"elapsed_ms", time.Since(startTime).Milliseconds(),
 				}
 
@@ -612,7 +616,7 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request) (*http.Resp
 				requestSpan.AddEvent("retry",
 					Attribute{Key: "retry.attempt", Value: attempt + 1},
 					Attribute{Key: "retry.reason", Value: retryReason},
-					Attribute{Key: "retry.delay_ms", Value: previewDelay.Milliseconds()},
+					Attribute{Key: "retry.delay_ms", Value: nextActualDelay.Milliseconds()},
 				)
 			}
 


### PR DESCRIPTION
## Summary

- **Consolidate duplicate slog adapters**: Remove unexported `slogAdapter` from `logger.go`, reuse exported `SlogAdapter` from `logger_slog.go` for `defaultLogger`
- **Fix timer leak**: Replace `time.After` with `time.NewTimer` + explicit `Stop()` on context cancellation to prevent resource leaks
- **Eliminate double delay computation**: Compute retry delay (with Retry-After, jitter, cap) once in phase 4, store and reuse in phase 1 — previously called twice producing different jitter values, causing misleading log output
- **Add retry reason constants**: Extract string literals into exported constants (`RetryReasonTimeout`, `RetryReason5xx`, etc.) for type safety and discoverability
- **Guard observability-only computation**: Skip `determineRetryReason` when all observability components are disabled

## Test plan

- [x] `make test` passes (93.3% coverage)
- [x] `make lint` passes (pre-existing gosec G704 unrelated to this change)
- [x] `TestClient_RetryAfterDelayLogging` validates logged delay matches Retry-After
- [x] `TestClient_DefaultLogger` updated to assert `*SlogAdapter` type
- [ ] Verify no behavioral changes in retry timing under real workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)