### PR TITLE
refactor: deduplicate buffered body setup and skip empty header clone

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -91,11 +91,13 @@ func LoggingMiddleware(logger Logger) Middleware {
 func HeaderMiddleware(headers map[string]string) Middleware {
 	return func(next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			// Clone request before modification (concurrent safety)
-			req = req.Clone(req.Context())
+			if len(headers) > 0 {
+				// Clone request before modification (concurrent safety)
+				req = req.Clone(req.Context())
 
-			for key, value := range headers {
-				req.Header.Set(key, value)
+				for key, value := range headers {
+					req.Header.Set(key, value)
+				}
 			}
 
 			return next.RoundTrip(req)

--- a/option.go
+++ b/option.go
@@ -266,16 +266,22 @@ func WithBody(contentType string, body io.Reader) RequestOption {
 			return
 		}
 
-		// Set both Body and GetBody to support request retries
-		req.Body = io.NopCloser(bytes.NewReader(data))
-		req.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(data)), nil
-		}
-		req.ContentLength = int64(len(data))
+		setBufferedBody(req, data, contentType)
+	}
+}
 
-		if contentType != "" {
-			req.Header.Set("Content-Type", contentType)
-		}
+// setBufferedBody buffers data as the request body and sets GetBody so the body
+// can be replayed on each retry. The Content-Type header is set only when
+// contentType is non-empty.
+func setBufferedBody(req *http.Request, data []byte, contentType string) {
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	req.ContentLength = int64(len(data))
+
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 }
 
@@ -320,13 +326,7 @@ func WithJSON(v any) RequestOption {
 			return
 		}
 
-		// Set both Body and GetBody to support request retries
-		req.Body = io.NopCloser(bytes.NewReader(data))
-		req.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(data)), nil
-		}
-		req.ContentLength = int64(len(data))
-		req.Header.Set("Content-Type", "application/json")
+		setBufferedBody(req, data, "application/json")
 	}
 }
 


### PR DESCRIPTION
## Summary

Quality-only cleanup from a full-codebase `/simplify` pass. No behavior changes — purely reuse and efficiency refinements.

- Extract a shared `setBufferedBody` helper that buffers a request body and sets a replayable `GetBody` plus `ContentLength`, with optional Content-Type
- Reuse the helper in both `WithBody` and `WithJSON`, removing the duplicated body-setup block
- Skip cloning the request in `HeaderMiddleware` when the header map is empty, avoiding a per-attempt allocation in the retry hot path

## Why

- `WithBody` and `WithJSON` repeated the identical `Body` + `GetBody` + `ContentLength` sequence — a single helper keeps the retry-replay body contract in one place
- `HeaderMiddleware` cloned the request on every attempt before checking whether any headers existed, wasting an allocation when there is nothing to set

## Classification

Leaf node — internal refactor, small and self-contained, public API unchanged.

## Testing

- `make test` — all tests pass, coverage 93.5%
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)